### PR TITLE
fix: StudyRepositoryTest 누락된 로직 추가 & Test 코드에서 initDb가 실행되지 않도록 수정

### DIFF
--- a/Back/src/main/java/com/bluecode/chatbot/config/InitDb.java
+++ b/Back/src/main/java/com/bluecode/chatbot/config/InitDb.java
@@ -17,7 +17,6 @@ import java.util.List;
  */
 
 @Component
-@Profile("dev")
 @RequiredArgsConstructor
 public class InitDb {
 

--- a/Back/src/test/java/com/bluecode/chatbot/repository/CurriculumRepositoryTest.java
+++ b/Back/src/test/java/com/bluecode/chatbot/repository/CurriculumRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.bluecode.chatbot.repository;
 
+import com.bluecode.chatbot.config.InitDb;
 import com.bluecode.chatbot.domain.*;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -7,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +21,9 @@ import java.util.List;
 class CurriculumRepositoryTest {
 
     @Autowired private CurriculumRepository curriculumRepository;
+
+    @MockBean
+    private InitDb initDb;
 
     @Test
     @DisplayName("findByRootIdAndChapterNum 쿼리 테스트")
@@ -87,6 +92,33 @@ class CurriculumRepositoryTest {
 
         for (int i = 0; i < 4; i++) {
             Assertions.assertThat(result.get(i)).isEqualTo(roots.get(i));
+        }
+    }
+
+    @Test
+    @DisplayName("curriculum update 테스트")
+    void changeTest() throws Exception {
+        //given
+        List<Curriculums> roots = new ArrayList<>();
+
+        for (int i = 0; i < 4; i++) {
+            Curriculums root = createCurriculum(null, String.format("Test용 root 커리큘럼명 %d", i + 1), "", "", "", false, 0);
+            roots.add(root);
+            curriculumRepository.save(root);
+        }
+
+        //when
+        List<Curriculums> result = curriculumRepository.findAllRootCurriculumList();
+        result.get(0).setCurriculumName(String.format("변경된 Test용 root 커리큘럼명 %d", 1));
+        curriculumRepository.save(result.get(0));
+
+        List<Curriculums> changedResult = curriculumRepository.findAllRootCurriculumList();
+
+        //then
+        Assertions.assertThat(result.size()).isEqualTo(roots.size());
+
+        for (int i = 0; i < 4; i++) {
+            Assertions.assertThat(result.get(i)).isEqualTo(changedResult.get(i));
         }
     }
 

--- a/Back/src/test/java/com/bluecode/chatbot/repository/StudyRepositoryTest.java
+++ b/Back/src/test/java/com/bluecode/chatbot/repository/StudyRepositoryTest.java
@@ -41,6 +41,10 @@ class StudyRepositoryTest {
         Curriculums chap2 = createCurriculum(root, "2. 파이썬 설치 환경", "2챕터 키워드 easy", "2챕터 키워드 normal", "2챕터 키워드 hard", false, 2);
         Curriculums chap3 = createCurriculum(root, "3. 파이썬 실행 원리", "3챕터 키워드 easy", "3챕터 키워드 normal", "3챕터 키워드 hard", true, 3);
 
+        curriculumRepository.save(chap1);
+        curriculumRepository.save(chap2);
+        curriculumRepository.save(chap3);
+
         chaps.add(chap1);
         chaps.add(chap2);
         chaps.add(chap3);
@@ -71,7 +75,6 @@ class StudyRepositoryTest {
             List<Studies> studies = result.get(i);
             Assertions.assertThat(studies.size()).isEqualTo(2);
         }
-
     }
 
     private Curriculums createCurriculum(

--- a/Back/src/test/java/com/bluecode/chatbot/repository/StudyRepositoryTest.java
+++ b/Back/src/test/java/com/bluecode/chatbot/repository/StudyRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.bluecode.chatbot.repository;
 
+import com.bluecode.chatbot.config.InitDb;
 import com.bluecode.chatbot.domain.Curriculums;
 import com.bluecode.chatbot.domain.LevelType;
 import com.bluecode.chatbot.domain.Studies;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +27,9 @@ class StudyRepositoryTest {
     @Autowired private UserRepository userRepository;
     @Autowired private CurriculumRepository curriculumRepository;
     @Autowired private StudyRepository studyRepository;
+
+    @MockBean
+    private InitDb initDb;
 
     @Test
     @DisplayName("findAllByCurriculumIdAndUserId 쿼리 테스트")
@@ -76,6 +81,56 @@ class StudyRepositoryTest {
             Assertions.assertThat(studies.size()).isEqualTo(2);
         }
     }
+    @Test
+    void findByUserIdAndCurriculumIdAndLevel() throws Exception {
+        //given
+        Users user = Users.createUser("testName", "testEmail", "testId", "1111", "22223344", true); // 초기 테스트 진행 유저 (3챕터에서 시작))
+        userRepository.save(user);
+        Curriculums root = createCurriculum(null, "Test용 루트 커리큘럼", "", "", "", false, 0);
+        curriculumRepository.save(root);
+
+        List<Curriculums> chaps = new ArrayList<>();
+
+        Curriculums chap1 = createCurriculum(root, "1. 프로그래밍 정의", "1챕터 키워드 easy", "1챕터 키워드 normal", "1챕터 키워드 hard", true, 1);
+        Curriculums chap2 = createCurriculum(root, "2. 파이썬 설치 환경", "2챕터 키워드 easy", "2챕터 키워드 normal", "2챕터 키워드 hard", false, 2);
+        Curriculums chap3 = createCurriculum(root, "3. 파이썬 실행 원리", "3챕터 키워드 easy", "3챕터 키워드 normal", "3챕터 키워드 hard", true, 3);
+
+        curriculumRepository.save(chap1);
+        curriculumRepository.save(chap2);
+        curriculumRepository.save(chap3);
+
+        chaps.add(chap1);
+        chaps.add(chap2);
+        chaps.add(chap3);
+
+        List<Studies> studiesEasy = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            Studies studies = createStudy(user, chaps.get(i), 60L + i, String.format("챕터 %d: " + LevelType.EASY + "EASY 학습자료: " + chaps.get(i).getCurriculumName() + String.format("테스트 Study 내용 입니다.: %d", i + 1), i + 1), true, LevelType.EASY);
+            studyRepository.save(studies);
+            studiesEasy.add(studies);
+        }
+
+        List<Studies> studiesNormal = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            Studies studies = createStudy(user, chaps.get(i), 60L + i, String.format("챕터 %d: " + LevelType.NORMAL + "NORMAL 학습자료: " + chaps.get(i).getCurriculumName() + String.format("테스트 Study 내용 입니다.: %d", i + 1), i + 1), true, LevelType.NORMAL);
+            studyRepository.save(studies);
+            studiesNormal.add(studies);
+        }
+
+        List<Studies> studiesHard = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            Studies studies = createStudy(user, chaps.get(i), 60L + i, String.format("챕터 %d: " + LevelType.HARD + "HARD 학습자료: " + chaps.get(i).getCurriculumName() + String.format("테스트 Study 내용 입니다.: %d", i + 1), i + 1), true, LevelType.HARD);
+            studyRepository.save(studies);
+            studiesHard.add(studies);
+        }
+        //when
+        Users findUser = userRepository.findByUserId(user.getUserId());
+        Studies result = studyRepository.findByUserIdAndCurriculumIdAndLevel(findUser.getUserId(), chap1.getCurriculumId(), LevelType.NORMAL);
+
+        //then
+        Assertions.assertThat(result).isEqualTo(studiesNormal.get(0));
+
+    }
 
     private Curriculums createCurriculum(
             Curriculums parent,
@@ -97,6 +152,7 @@ class StudyRepositoryTest {
 
         return curriculums;
     }
+
 
     private Studies createStudy(
             Users user,


### PR DESCRIPTION
StudyRepositoryTest 누락된 로직 추가

- findAllByCurriculumIdAndUserId 쿼리 테스트에서 chap을 DB에 저장하는 로직 추가
- Test 코드에서 initDb가 실행되는 문제가 발생하지 않도록 Test 코드에 Moking을 통한 코드 수정