### PR TITLE
fix: test 분리 관련 로직 수정

### DIFF
--- a/Back/src/main/java/com/bluecode/chatbot/config/InitDb.java
+++ b/Back/src/main/java/com/bluecode/chatbot/config/InitDb.java
@@ -6,7 +6,6 @@ import jakarta.annotation.PostConstruct;
 import jakarta.persistence.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/Back/src/main/java/com/bluecode/chatbot/repository/StudyRepository.java
+++ b/Back/src/main/java/com/bluecode/chatbot/repository/StudyRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface StudyRepository extends JpaRepository<Studies, Long>, StudyRepositoryCustom {
 
@@ -17,5 +19,5 @@ public interface StudyRepository extends JpaRepository<Studies, Long>, StudyRepo
             "where s.user.userId = :userId " +
             "and s.curriculum.curriculumId = :curriculumId" +
             " and s.level = :levelType")
-    Studies findByUserIdAndCurriculumIdAndLevel(@Param("userId") Long userId, @Param("curriculumId") Long curriculumId, @Param("levelType") LevelType levelType);
+    Optional<Studies> findByUserIdAndCurriculumIdAndLevel(@Param("userId") Long userId, @Param("curriculumId") Long curriculumId, @Param("levelType") LevelType levelType);
 }

--- a/Back/src/main/java/com/bluecode/chatbot/repository/StudyRepository.java
+++ b/Back/src/main/java/com/bluecode/chatbot/repository/StudyRepository.java
@@ -7,8 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository
 public interface StudyRepository extends JpaRepository<Studies, Long>, StudyRepositoryCustom {
 
@@ -19,5 +17,5 @@ public interface StudyRepository extends JpaRepository<Studies, Long>, StudyRepo
             "where s.user.userId = :userId " +
             "and s.curriculum.curriculumId = :curriculumId" +
             " and s.level = :levelType")
-    Optional<Studies> findByUserIdAndCurriculumIdAndLevel(@Param("userId") Long userId, @Param("curriculumId") Long curriculumId, @Param("levelType") LevelType levelType);
+    Studies findByUserIdAndCurriculumIdAndLevel(@Param("userId") Long userId, @Param("curriculumId") Long curriculumId, @Param("levelType") LevelType levelType);
 }

--- a/Back/src/main/java/com/bluecode/chatbot/repository/UserRepository.java
+++ b/Back/src/main/java/com/bluecode/chatbot/repository/UserRepository.java
@@ -2,7 +2,9 @@ package com.bluecode.chatbot.repository;
 
 import com.bluecode.chatbot.domain.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface UserRepository extends JpaRepository<Users, Long> {
 
     // 유저 테이블 id 기반 user 검색

--- a/Back/src/test/java/com/bluecode/chatbot/repository/CurriculumRepositoryTest.java
+++ b/Back/src/test/java/com/bluecode/chatbot/repository/CurriculumRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.bluecode.chatbot.repository;
 
-import com.bluecode.chatbot.config.InitDb;
 import com.bluecode.chatbot.domain.*;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -8,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,10 +19,6 @@ import java.util.List;
 class CurriculumRepositoryTest {
 
     @Autowired private CurriculumRepository curriculumRepository;
-
-    @MockBean
-    private InitDb initDb;
-
     @Test
     @DisplayName("findByRootIdAndChapterNum 쿼리 테스트")
     void findByRootIdAndChapterNum_query_test() throws Exception {
@@ -76,7 +70,7 @@ class CurriculumRepositoryTest {
     @DisplayName("findAllRootCurriculumList 쿼리 테스트")
     void findAllRootCurriculumList() throws Exception {
         //given
-        List<Curriculums> roots = new ArrayList<>();
+        List<Curriculums> roots = curriculumRepository.findAllRootCurriculumList();
 
         for (int i = 0; i < 4; i++) {
             Curriculums root = createCurriculum(null, String.format("Test용 root 커리큘럼명 %d", i + 1), "", "", "", false, 0);
@@ -90,8 +84,8 @@ class CurriculumRepositoryTest {
         //then
         Assertions.assertThat(result.size()).isEqualTo(roots.size());
 
-        for (int i = 0; i < 4; i++) {
-            Assertions.assertThat(result.get(i)).isEqualTo(roots.get(i));
+        for (int i = 0; i < result.size(); i++) {
+            Assertions.assertThat(result.get(i)).isIn(roots);
         }
     }
 
@@ -99,7 +93,7 @@ class CurriculumRepositoryTest {
     @DisplayName("curriculum update 테스트")
     void changeTest() throws Exception {
         //given
-        List<Curriculums> roots = new ArrayList<>();
+        List<Curriculums> roots = curriculumRepository.findAllRootCurriculumList();
 
         for (int i = 0; i < 4; i++) {
             Curriculums root = createCurriculum(null, String.format("Test용 root 커리큘럼명 %d", i + 1), "", "", "", false, 0);
@@ -117,7 +111,7 @@ class CurriculumRepositoryTest {
         //then
         Assertions.assertThat(result.size()).isEqualTo(roots.size());
 
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < result.size(); i++) {
             Assertions.assertThat(result.get(i)).isEqualTo(changedResult.get(i));
         }
     }

--- a/Back/src/test/java/com/bluecode/chatbot/repository/StudyRepositoryTest.java
+++ b/Back/src/test/java/com/bluecode/chatbot/repository/StudyRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.bluecode.chatbot.repository;
 
-import com.bluecode.chatbot.config.InitDb;
 import com.bluecode.chatbot.domain.Curriculums;
 import com.bluecode.chatbot.domain.LevelType;
 import com.bluecode.chatbot.domain.Studies;
@@ -11,7 +10,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,9 +25,6 @@ class StudyRepositoryTest {
     @Autowired private UserRepository userRepository;
     @Autowired private CurriculumRepository curriculumRepository;
     @Autowired private StudyRepository studyRepository;
-
-    @MockBean
-    private InitDb initDb;
 
     @Test
     @DisplayName("findAllByCurriculumIdAndUserId 쿼리 테스트")
@@ -82,6 +77,7 @@ class StudyRepositoryTest {
         }
     }
     @Test
+    @DisplayName("findByUserIdAndCurriculumIdAndLevel 쿼리 테스트")
     void findByUserIdAndCurriculumIdAndLevel() throws Exception {
         //given
         Users user = Users.createUser("testName", "testEmail", "testId", "1111", "22223344", true); // 초기 테스트 진행 유저 (3챕터에서 시작))

--- a/Back/src/test/java/com/bluecode/chatbot/repository/StudyRepositoryTest.java
+++ b/Back/src/test/java/com/bluecode/chatbot/repository/StudyRepositoryTest.java
@@ -121,7 +121,7 @@ class StudyRepositoryTest {
         }
         //when
         Users findUser = userRepository.findByUserId(user.getUserId());
-        Studies result = studyRepository.findByUserIdAndCurriculumIdAndLevel(findUser.getUserId(), chap1.getCurriculumId(), LevelType.NORMAL);
+        Studies result = studyRepository.findByUserIdAndCurriculumIdAndLevel(findUser.getUserId(), chap1.getCurriculumId(), LevelType.NORMAL).get();
 
         //then
         Assertions.assertThat(result).isEqualTo(studiesNormal.get(0));


### PR DESCRIPTION
test 코드에서도 initDb 데이터를 활용하는 것으로 변경

fix: StudyRepository 특정 쿼리 리턴 자료형 수정

- 유저 테이블 id, 커리큘럼 id, level 기반 Studies 단일 검색 쿼리의 return 형식을 Optional<Studies>로 수정함(단일 리턴은 값이 존재하지 않으면 exception을 발생시키기 때문)